### PR TITLE
docs: enhance README with project structure and development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,31 @@
 # Game Master Monorepo
 
-## Under Construction
-It became clear that the game master project would benefit from a monorepo setup to share API logic between the dedicated handler and the Remix client. Currently under construction.
+A Dungeons & Dragons campaign management tool with a Phoenix/Elixir backend and React/TanStack frontend.
+
+## Project Structure
+
+This monorepo uses `pnpm` workspaces and Turbo for build orchestration:
+
+- **packages/** - Shared packages and utilities
+- **apps/** - Application services (API handler, Remix client)
+
+The separation enables code sharing between the API and frontend while maintaining clean package boundaries.
+
+## Development
+
+Install dependencies:
+```bash
+pnpm install
+```
+
+Run development servers:
+```bash
+pnpm dev
+```
+
+Run tests:
+```bash
+pnpm test
+```
+
+See individual package READMEs for more detailed setup.


### PR DESCRIPTION
Updates the README to move beyond the "under construction" placeholder.

Adds:
- Clear project description
- Monorepo structure overview
- Development setup instructions
- Commands for installation, dev servers, and tests